### PR TITLE
Feature: simple first pass addition of LinearSVC

### DIFF
--- a/shared/lib/index.ts
+++ b/shared/lib/index.ts
@@ -70,6 +70,7 @@ import {
   VotingRegressor,
   VotingRegressorParams
 } from './ensemble/votingRegressor'
+import { LinearSVC, LinearSVCParams } from './svm/linearSVC'
 
 export {
   MinMaxScaler,
@@ -98,6 +99,8 @@ export {
   RidgeRegressionParams,
   LogisticRegression,
   LogisticRegressionParams,
+  LinearSVC,
+  LinearSVCParams,
   ElasticNet,
   ElasticNetParams,
   metrics,

--- a/shared/lib/svm/linearSVC.test.ts
+++ b/shared/lib/svm/linearSVC.test.ts
@@ -1,0 +1,94 @@
+import '@tensorflow/tfjs-backend-webgl'
+import { assert } from 'chai'
+import { LinearSVC } from './linearSVC'
+import { describe, it } from 'mocha'
+
+describe('LinearSVC', function () {
+  this.timeout(30000)
+  it('Works on arrays (small example)', async function () {
+    const lr = new LinearSVC()
+
+    await lr.fit([[1], [2]], [0, 1])
+    assert.deepEqual(lr.predict([[1], [2]]).arraySync(), [0, 1])
+  })
+  it('Test of the function used with 2 classes', async function () {
+    let X = [
+      [0, -1],
+      [1, 0],
+      [1, 1],
+      [1, -1],
+      [2, 0],
+      [2, 1],
+      [2, -1],
+      [3, 2],
+      [0, 4],
+      [1, 3],
+      [1, 4],
+      [1, 5],
+      [2, 3],
+      [2, 4],
+      [2, 5],
+      [3, 4]
+    ]
+    let y = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]
+
+    let Xtest = [
+      [0, -2],
+      [1, 0.5],
+      [1.5, -1],
+      [1, 4.5],
+      [2, 3.5],
+      [1.5, 5]
+    ]
+
+    let svc = new LinearSVC({ penalty: 'none' })
+    await svc.fit(X, y)
+    let results = svc.predict(Xtest) // compute results of the training set
+    assert.deepEqual(results.arraySync(), [0, 0, 0, 1, 1, 1])
+    assert.isTrue(svc.score(X, y) > 0.5)
+  })
+  it('Test of the prediction with 3 classes', async function () {
+    let X = [
+      [0, -1],
+      [1, 0],
+      [1, 1],
+      [1, -1],
+      [2, 0],
+      [2, 1],
+      [2, -1],
+      [3, 2],
+      [0, 4],
+      [1, 3],
+      [1, 4],
+      [1, 5],
+      [2, 3],
+      [2, 4],
+      [2, 5],
+      [3, 4],
+      [1, 10],
+      [1, 12],
+      [2, 10],
+      [2, 11],
+      [2, 14],
+      [3, 11]
+    ]
+    let y = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2]
+
+    let Xtest = [
+      [0, -2],
+      [1, 0.5],
+      [1.5, -1],
+      [1, 2.5],
+      [2, 3.5],
+      [1.5, 4],
+      [1, 10.5],
+      [2.5, 10.5],
+      [2, 11.5]
+    ]
+
+    let svc = new LinearSVC({ penalty: 'none' })
+    await svc.fit(X, y)
+    let finalResults = svc.predict(Xtest)
+    assert.deepEqual(finalResults.arraySync(), [0, 0, 0, 1, 1, 1, 2, 2, 2])
+  })
+})

--- a/shared/lib/svm/linearSVC.ts
+++ b/shared/lib/svm/linearSVC.ts
@@ -1,0 +1,103 @@
+// /**
+// *  @license
+// * Copyright 2021, JsData. All rights reserved.
+// *
+// * This source code is licensed under the MIT license found in the
+// * LICENSE file in the root directory of this source tree.
+
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// * ==========================================================================
+// */
+
+import { losses, train } from '@tensorflow/tfjs-core'
+import { callbacks } from '@tensorflow/tfjs-layers'
+import { SGDClassifier } from '../estimators/sgdClassifier'
+import { tf } from '../../globals'
+
+// First pass at a LinearSVC implementation using gradient descent
+// Trying to mimic the API of scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearSVC.html
+
+/*
+Next steps:
+1. Support elasticnet penalty
+2. Support tol and maxIter (might need to change sgd.linear)
+3. Implement randomState
+4. Implement attribute "classes"
+5. Pass next 5 scikit-learn tests
+*/
+
+export interface LinearSVCParams {
+  /** Specify the norm of the penalty. **default = l2** */
+  penalty?: 'l1' | 'l2' | 'none'
+  /** Inverse of the regularization strength. **default = 1** */
+  C?: number
+  /** Whether or not the intercept should be estimator not. **default = true** */
+  fitIntercept?: boolean
+}
+
+/** Builds a linear classification model with associated penalty and regularization
+ *
+ * @example
+ * ```js
+ * let X = [
+      [1, -1],
+      [2, 0],
+      [2, 1],
+      [2, -1],
+      [3, 2],
+      [0, 4],
+      [1, 3],
+      [1, 4],
+      [1, 5],
+      [2, 3],
+    ]
+    let y = [ 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
+
+    let svc = new LinearSVC()
+    await svc.fit(X, y)
+ * ```
+*/
+export class LinearSVC extends SGDClassifier {
+  /** Useful for pipelines and column transformers to have a default name for transforms */
+  name = 'LinearSVC'
+
+  constructor({
+    penalty = 'l2',
+    C = 1,
+    fitIntercept = true
+  }: LinearSVCParams = {}) {
+    // Assume Binary classification
+    // If we call fit, and it isn't binary then update args
+    super({
+      modelCompileArgs: {
+        optimizer: train.adam(0.1),
+        loss: losses.hingeLoss,
+        metrics: ['accuracy']
+      },
+      modelFitArgs: {
+        batchSize: 32,
+        epochs: 1000,
+        verbose: 0,
+        callbacks: [callbacks.earlyStopping({ monitor: 'loss', patience: 50 })]
+      },
+      denseLayerArgs: {
+        units: 1,
+        useBias: Boolean(fitIntercept),
+        activation: 'softmax',
+        kernelInitializer: tf.initializers.zeros(),
+        biasInitializer: tf.initializers.zeros(),
+        kernelRegularizer:
+          penalty === 'l2'
+            ? tf.regularizers.l2({ l2: C })
+            : penalty === 'l1'
+            ? tf.regularizers.l1({ l1: C })
+            : undefined
+      },
+      isClassification: true
+    })
+  }
+}


### PR DESCRIPTION
Uses our SGDClassifier to perform a LinearSVC. 

In the long term I think we should port LIBLINEAR(https://www.csie.ntu.edu.tw/~cjlin/liblinear/) into wasm and use that to perform LinearSVC, LinearSVR, and LogisticRegression