### PR TITLE
chore: correct the error message in case of empty input for metrics

### DIFF
--- a/shared/lib/metrics/metrics.test.ts
+++ b/shared/lib/metrics/metrics.test.ts
@@ -76,4 +76,9 @@ describe('Metrics', function () {
     const predictions = [0.5, 0.5]
     assert.deepEqual(metrics.rocAucScore(labels, predictions), 0.5)
   })
+  it('empty input', function () {
+    const labels: number[] = []
+    const predictions: number[] = []
+    assert.throws(() => metrics.accuracyScore(labels, predictions), Error)
+  })
 })

--- a/shared/lib/metrics/metrics.ts
+++ b/shared/lib/metrics/metrics.ts
@@ -29,8 +29,8 @@ function assertInputIsWellFormed(labels: Scikit1D, predictions: Scikit1D) {
 
   let labelsT = convertToNumericTensor1D(labels)
   let predictionsT = convertToNumericTensor1D(predictions)
-  assert(labelsT.size > 0, 'Must be more than 1 label')
-  assert(predictionsT.size > 0, 'Must be more than 1 prediction')
+  assert(labelsT.size > 0, 'Must have 1 label or more')
+  assert(predictionsT.size > 0, 'Must have 1 prediction or more')
   assert(labelsT.size === predictionsT.size, 'Not the same size arrays')
   return { labelsT, predictionsT }
 }


### PR DESCRIPTION
Since 'more than' is not inclusive, we should be explicit not to allow only empty labels/predictions.