### PR TITLE
test: custom jest tensor matchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "node_modules/.bin/jest src/**/*.test.ts --coverage",
-    "test:ci": "node_modules/.bin/jest src/**/*.test.ts --coverage --runInBand --ci",
-    "test:clean": "node_modules/.bin/jest src/**/*.test.ts --coverage && npm run prettier:check",
+    "test": "node_modules/.bin/jest src/**/*.test.ts src/*.test.ts --coverage",
+    "test:ci": "node_modules/.bin/jest src/**/*.test.ts src/*.test.ts --coverage --runInBand --ci",
+    "test:clean": "node_modules/.bin/jest src/**/*.test.ts src/*.test.ts --coverage && npm run prettier:check",
     "compile:web": "node_modules/.bin/rollup -c",
     "compile:esm": "node_modules/.bin/tsc -p tsconfig.build-esm.json && node_modules/.bin/tsc-alias -p tsconfig.build-esm.json",
     "compile:node-cjs": "node_modules/.bin/tsc -p tsconfig.build-node.json && node_modules/.bin/tsc-alias -p tsconfig.build-node.json",

--- a/src/jestTensorMatchers.test.ts
+++ b/src/jestTensorMatchers.test.ts
@@ -1,0 +1,85 @@
+/**
+*  @license
+* Copyright 2022, JsData. All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* ==========================================================================
+*/
+
+import './jestTensorMatchers'
+
+describe('Custom Jest Tensor Matchers', () => {
+  it('passes handcrafted tests', () => {
+    expect([1, 1, 1]).toBeAllCloseTo(1, { rtol: 0, atol: 0 })
+
+    expect([1, 2, 3, 4]).toBeAllLessOrClose(4, { rtol: 0, atol: 0 })
+
+    expect([
+      [5, 6],
+      [7, 8]
+    ]).toBeAllGreaterOrClose(5, { rtol: 0, atol: 0 })
+
+    expect([
+      [30, 3],
+      [10, 1],
+      [20, 2]
+    ]).toBeAllGreaterOrClose([10, 1], { rtol: 0, atol: 0 })
+
+    expect([
+      [30, 3],
+      [1, 10],
+      [20, 2]
+    ]).toBeAllGreaterOrClose([[3], [1], [2]], { rtol: 0, atol: 0 })
+
+    expect([
+      [
+        [+1.01, -2.02, +3.03],
+        [-4.04, +5.05, -6.06]
+      ],
+      [
+        [-10.1, +20.2, +30.3],
+        [+40.4, -50.5, -60.6]
+      ]
+    ]).toBeAllCloseTo(
+      [
+        [
+          [+1, -2, +3],
+          [-4, +5, -6]
+        ],
+        [
+          [-10, +20, +30],
+          [+40, -50, -60]
+        ]
+      ],
+      { rtol: 0.0101, atol: 0 }
+    )
+
+    expect([
+      [
+        [+1, +20, -3, -40],
+        [-50, -6, +70, -8]
+      ]
+    ]).toBeAllCloseTo(
+      [
+        [
+          [+1.01, +20.01, -3.01, -40.01],
+          [-49.99, -5.99, +69.99, -7.99]
+        ],
+        [
+          [+1.01, +19.99, -2.99, -40.01],
+          [-50.01, -5.99, +69.99, -8.01]
+        ]
+      ],
+      { rtol: 0, atol: 0.0101 }
+    )
+
+    expect([0.99, 1.99]).toBeAllLessNotClose([1, 2], { rtol: 0, atol: 0.0095 })
+  })
+})

--- a/src/jestTensorMatchers.test.ts
+++ b/src/jestTensorMatchers.test.ts
@@ -81,5 +81,19 @@ describe('Custom Jest Tensor Matchers', () => {
     )
 
     expect([0.99, 1.99]).toBeAllLessNotClose([1, 2], { rtol: 0, atol: 0.0095 })
+
+    expect([1, 2]).not.toBeAllCloseTo([1.1, 2.1], { rtol: 0.05 })
+
+    expect(() =>
+      expect([1, 2, 3, 4]).toBeAllCloseTo([1, 2.1, 3, 4], { rtol: 0.01 })
+    ).toThrow()
+
+    expect(() => expect([]).toBeAllCloseTo([])).toThrow()
+    expect(() => expect([1]).toBeAllCloseTo([])).toThrow()
+    expect(() => expect([]).toBeAllCloseTo([2])).toThrow()
+
+    expect([]).toBeAllCloseTo([], { allowEmpty: true })
+    expect([1]).toBeAllCloseTo([], { allowEmpty: true })
+    expect([]).toBeAllCloseTo([2], { allowEmpty: true })
   })
 })

--- a/src/jestTensorMatchers.ts
+++ b/src/jestTensorMatchers.ts
@@ -1,0 +1,306 @@
+/**
+*  @license
+* Copyright 2022, JsData. All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* ==========================================================================
+*/
+
+import { tf } from './shared/globals'
+import { Tensor, TensorLike } from '@tensorflow/tfjs-core'
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R, T> {
+      /**
+       * Tests whether or not each entry of a Tensor(Like) is close
+       * to the corresponding entry of an expected tensor.
+       *
+       * @param expected The expected result tensor.
+       * @param params Tolerance and broadcast settings. `{broadcast: false}` disallows
+       *               broadcasting, i.e. the result tensor must have the same shape as
+       *               the expected tensor. `{rtol, atol}` are the relative and absolute
+       *               tolerance parameter. Two entries `x` and `y` are considered equal
+       *               iff `|x-y| <= max(|x|, |y|)*rtol + atol`. Set `{rtol: 0, atol: 0}`
+       *               for exact equality.
+       */
+      toBeAllCloseTo: T extends Tensor | TensorLike
+        ? (
+            expected: Tensor | TensorLike,
+            params?: { rtol?: number; atol?: number; broadcast?: boolean }
+          ) => R
+        : undefined
+      toBeAllLessOrClose: T extends Tensor | TensorLike
+        ? (
+            expected: Tensor | TensorLike,
+            params?: { rtol?: number; atol?: number; broadcast?: boolean }
+          ) => R
+        : undefined
+      toBeAllGreaterOrClose: T extends Tensor | TensorLike
+        ? (
+            expected: Tensor | TensorLike,
+            params?: { rtol?: number; atol?: number; broadcast?: boolean }
+          ) => R
+        : undefined
+      toBeAllLessNotClose: T extends Tensor | TensorLike
+        ? (
+            expected: Tensor | TensorLike,
+            params?: { rtol?: number; atol?: number; broadcast?: boolean }
+          ) => R
+        : undefined
+      toBeAllGreaterNotClose: T extends Tensor | TensorLike
+        ? (
+            expected: Tensor | TensorLike,
+            params?: { rtol?: number; atol?: number; broadcast?: boolean }
+          ) => R
+        : undefined
+    }
+  }
+}
+
+/**
+ * Takes a flat index and turns it into an nd-index for
+ * the given shape.
+ *
+ * @param flat Index into the flattened data array of a Tensor.
+ * @param shape Shape of a Tensor.
+ * @returns The nd-index into a Tensor of shape `shape`.
+ */
+function unravelIndex(flat: number, shape: number[]) {
+  // see: https://numpy.org/doc/stable/reference/generated/numpy.unravel_index.html
+  shape = shape.slice()
+  for (let i = shape.length; i-- > 0; ) {
+    const si = shape[i]
+    shape[i] = flat % si
+    flat = Math.trunc(flat / si)
+  }
+  return shape
+}
+
+const isClose =
+  ({ rtol = 1e-3, atol = 1e-6 }) =>
+  (x: number, y: number) => {
+    const xa = Math.abs(x)
+    const ya = Math.abs(y)
+    const tol = Math.max(xa, ya) * rtol + atol
+    return Math.abs(x - y) <= tol
+  }
+
+const isLessOrClose =
+  ({ rtol = 1e-3, atol = 1e-6 }) =>
+  (x: number, y: number) => {
+    const xa = Math.abs(x)
+    const ya = Math.abs(y)
+    const tol = Math.max(xa, ya) * rtol + atol
+    return x - y <= tol
+  }
+
+const isLessNotClose =
+  ({ rtol = 1e-3, atol = 1e-6 }) =>
+  (x: number, y: number) => {
+    const xa = Math.abs(x)
+    const ya = Math.abs(y)
+    const tol = Math.max(xa, ya) * rtol + atol
+    return x - y < -tol
+  }
+
+export function toBeAll(
+  this: { isNot: boolean },
+  result: TensorLike | Tensor,
+  expect: TensorLike | Tensor,
+  { broadcast = true },
+  description: string,
+  match: (x: number, y: number) => boolean
+) {
+  const { isNot } = this
+  const a = result instanceof Tensor ? result : tf.tensor(result)
+  const b = expect instanceof Tensor ? expect : tf.tensor(expect)
+
+  const msg = (msg: string) => () =>
+    `\nA: ${a.toString(true)}\nB: ${b.toString(true)}\nExpected A ${
+      isNot ? 'not ' : ''
+    }to be all ${description} B but:\n${msg}`
+
+  const rankA = a.rank
+  const rankB = b.rank
+  const rank = Math.max(rankA, rankB)
+
+  const shapeA = a.shape
+  const shapeB = b.shape
+  const shape = [...(rankB < rankA ? shapeA : shapeB)]
+
+  // CHECK SHAPES
+  // ------------
+  {
+    let i = rankA
+    let j = rankB
+
+    if (broadcast) {
+      while (i-- > 0 && j-- > 0) {
+        const sa = shapeA[i]
+        const sb = shapeB[j]
+        if (sa !== sb && sa !== 1 && sb !== 1) {
+          return {
+            message: msg('A.shape not broadcast-compatible to B.shape'),
+            pass: isNot
+          }
+        }
+        shape[Math.max(i, j)] = Math.max(sa, sb)
+      }
+    } else {
+      if (i !== j) {
+        return {
+          message: msg('A.shape does not match B.shape'),
+          pass: isNot
+        }
+      }
+      while (i-- > 0 && j-- > 0) {
+        if (shapeA[i] !== shapeB[j]) {
+          return {
+            message: msg('A.shape does not match B.shape'),
+            pass: isNot
+          }
+        }
+      }
+    }
+  }
+
+  // CHECK DATA
+  // ----------
+  const aFlat = a.dataSync()
+  const bFlat = b.dataSync()
+
+  let ia = 0
+  let ib = 0
+  let strideA: number
+  let strideB: number
+
+  function visit(axis: number) {
+    if (axis === rank) {
+      if (!match(aFlat[ia], bFlat[ib])) {
+        throw msg(
+          `A(${unravelIndex(ia, shapeA)}) = ${aFlat[ia]}\nB(${unravelIndex(
+            ib,
+            shapeB
+          )}) = ${bFlat[ib]}`
+        )
+      }
+      ia += strideA = 1
+      ib += strideB = 1
+    } else {
+      for (let i = 0; ; ) {
+        visit(axis + 1)
+        if (++i >= shape[axis]) break
+        if (!(shapeA[axis - rank + rankA] > 1)) ia -= strideA
+        if (!(shapeB[axis - rank + rankB] > 1)) ib -= strideB
+      }
+      strideA *= shapeA[axis - rank + rankA] ?? 1
+      strideB *= shapeB[axis - rank + rankB] ?? 1
+    }
+  }
+
+  try {
+    visit(0)
+    return { pass: true, message: msg('It is.') }
+  } catch (message) {
+    return { pass: false, message: message as () => string }
+  }
+}
+
+export function toBeAllCloseTo(
+  this: { isNot: boolean },
+  result: TensorLike | Tensor,
+  expect: TensorLike | Tensor,
+  params: { rtol?: number; atol?: number; broadcast?: boolean } = {}
+) {
+  return toBeAll.call(
+    this,
+    result,
+    expect,
+    params,
+    'close to',
+    isClose(params)
+  )
+}
+
+export function toBeAllLessOrClose(
+  this: { isNot: boolean },
+  result: TensorLike | Tensor,
+  expect: TensorLike | Tensor,
+  params: { rtol?: number; atol?: number; broadcast?: boolean } = {}
+) {
+  return toBeAll.call(
+    this,
+    result,
+    expect,
+    params,
+    'close to or less than',
+    isLessOrClose(params)
+  )
+}
+
+export function toBeAllGreaterOrClose(
+  this: { isNot: boolean },
+  result: TensorLike | Tensor,
+  expect: TensorLike | Tensor,
+  params: { rtol?: number; atol?: number; broadcast?: boolean } = {}
+) {
+  const le = isLessOrClose(params)
+  return toBeAll.call(
+    this,
+    result,
+    expect,
+    params,
+    'close to or greater than',
+    (x, y) => le(y, x)
+  )
+}
+
+export function toBeAllLessNotClose(
+  this: { isNot: boolean },
+  result: TensorLike | Tensor,
+  expect: TensorLike | Tensor,
+  params: { rtol?: number; atol?: number; broadcast?: boolean } = {}
+) {
+  return toBeAll.call(
+    this,
+    result,
+    expect,
+    params,
+    'less than not close to',
+    isLessNotClose(params)
+  )
+}
+
+export function toBeAllGreaterNotClose(
+  this: { isNot: boolean },
+  result: TensorLike | Tensor,
+  expect: TensorLike | Tensor,
+  params: { rtol?: number; atol?: number; broadcast?: boolean } = {}
+) {
+  const le = isLessNotClose(params)
+  return toBeAll.call(
+    this,
+    result,
+    expect,
+    params,
+    'greater than not close to',
+    (x, y) => le(y, x)
+  )
+}
+
+expect.extend({
+  toBeAllCloseTo,
+  toBeAllLessOrClose,
+  toBeAllLessNotClose,
+  toBeAllGreaterOrClose,
+  toBeAllGreaterNotClose
+})


### PR DESCRIPTION
This commit aims to offer utility methods for testing Tensor equality and inequality in Jest. The approximate equality was inspired by [numpy.isclose](https://numpy.org/doc/stable/reference/generated/numpy.isclose.html). Broadcasting is enabled by default.

What do You guys think? Does this make sense? Are there any suggestions?