### PR TITLE
casing info fix

### DIFF
--- a/CONTRIBUTING_GUIDE.md
+++ b/CONTRIBUTING_GUIDE.md
@@ -42,7 +42,7 @@ Some important scripts in the package.json file are:
 
 ### File names
 
-File names must be all snakecase names that specify the function or class that is inside. E.g `labelEncoder.ts` houses the class `LabelEncoder`. `trainTestSplit.ts` contains the function `trainTestSplit`.
+File names must be all lowerCamelCase names that specify the function or class that is inside. E.g `labelEncoder.ts` houses the class `LabelEncoder`. `trainTestSplit.ts` contains the function `trainTestSplit`.
 
 ### Source file structure
 


### PR DESCRIPTION
I believe there was a mistake in the CONTRIBUTION_GUIDE.md where it stated `snakecase` for file names, when I believe the desired casing (the one being used in the project) would be `lowerCamelCase`. In my understading `snake_case_is_like_this`, whereas the project uses `thisFormatForFileNames`, which I understand as `lowerCamelCase`. :)