### PR TITLE
fixing readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const y = [10, 20]
 
 await lr.fit(X, y)
 
-lr.predict([[3, 4]]) // roughly [30, 40]
+lr.predict([[3], [4]]) // roughly [30, 40]
 console.log(lr.coef)
 console.log(lr.intercept)
 ```


### PR DESCRIPTION
I believe there was a small error in the documentation (look at how the array was flat in the predict()).

If I run the code how it was, I receive the following error:

```
var _this = _super.call(this, message) || this;
                   ^

ValueError: Error when checking : expected dense_Dense1_input to have shape [null,1] but got array with shape [1,2].
    at new ValueError (.../node_modules/@tensorflow/tfjs-layers/dist/tf-layers.node.js:10080:28)
    at checkInputData (.../node_modules/@tensorflow/tfjs-layers/dist/tf-layers.node.js:19373:31)
    at LayersModel.predict (.../node_modules/@tensorflow/tfjs-layers/dist/tf-layers.node.js:20051:9)
    at Sequential.predict (.../node_modules/@tensorflow/tfjs-layers/dist/tf-layers.node.js:21555:27)
    at LinearRegression.predict (.../dist/node/linear_model/sgdRegressor.js:204:40)
    at main (.../test/mock/basic-node.mjs:10:18)
```

So I made the change to what I believe to be the intended way - but let me know if I'm not correct!

:)